### PR TITLE
Wrongly capitalized L in BlocklyServerProtocol fixed.

### DIFF
--- a/scripts/blockly_backend.py
+++ b/scripts/blockly_backend.py
@@ -40,7 +40,7 @@ from autobahn.asyncio.websocket import WebSocketServerProtocol, \
 import roslaunch
 import os
 
-class BLocklyServerProtocol(WebSocketServerProtocol):
+class BlocklyServerProtocol(WebSocketServerProtocol):
     def onConnect(self, request):
         print("Client connecting: {0}".format(request.peer))
 


### PR DESCRIPTION
Was getting this error before the fix:

    rosrun blockly blockly_backend.py

    Traceback (most recent call last):
      File "/home/lucasw/ros_catkin_ws/src/ros_blockly/scripts/blockly_backend.py", line 137, in <module>
        talker()
      File "/home/lucasw/ros_catkin_ws/src/ros_blockly/scripts/blockly_backend.py", line 119, in talker
        factory.protocol = BlocklyServerProtocol
    NameError: name 'BlocklyServerProtocol' is not defined
